### PR TITLE
Fix: Escape relayhost used as regex when setting SASL credentials

### DIFF
--- a/tasks/auth.yml
+++ b/tasks/auth.yml
@@ -58,7 +58,7 @@
     - name: "Set SASL credentials in sasl_passwd"
       ansible.builtin.lineinfile:
         path: /etc/postfix/sasl_passwd
-        regexp: "^{{ postfix_relayhost }}"
+        regexp: "^{{ postfix_relayhost | ansible.builtin.regex_escape() }}"
         line: "{{ postfix_relayhost }} {{ postfix_sasl_username }}:{{ postfix_sasl_password | quote }}"
         state: present
       notify:


### PR DESCRIPTION
When writing the SASL credentials to `sasl_passwd`, the `lineinfile` module is used. To update the file, the `postfix_relayhost` variable is used as `regexp`, literally.
If that variable contains characters that are reserved for regex (e.g. `[`,  `]` or `.`), the expression will not identify the line and add a new line every time the role is run and the SASL username and/or password changed.

This pull request adds a `regex_escape()` filter to prevent this from happening.